### PR TITLE
Fix builds on osx (and elsewhere?)

### DIFF
--- a/ext/capn_proto/extconf.rb
+++ b/ext/capn_proto/extconf.rb
@@ -14,6 +14,8 @@ CONFIG['CXXFLAGS'] = [(ENV['CXXFLAGS'] || CONFIG['CXXFLAGS']),
                       compiler.std_flag,
                       compiler.stdlib_flag].join(' ')
 
+$CXXFLAGS = CONFIG['CXXFLAGS']
+
 if enable_config('debug')
   CONFIG['CFLAGS'] += " -O0 -ggdb3"
 else


### PR DESCRIPTION
Set a global variable with the CXXFLAGS so that the make file generating code can see it.
This is mimicking what the code already does for the LDFLAGS and it works for me.

Without this the make file would not be informed of the `-std=c++11` flag set in my env. Weirdly enough the `CXX` env var _is_ seen in the makefile. I cannot explain this behavior.
